### PR TITLE
Fix version field in the published package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,11 @@ jobs:
       - run: npm ci
 
       - run: ./node_modules/.bin/tsc
-      - run: cat package.json | jq --arg VERSION "${{ github.event.release.tag_name }}" 'del(.devDependencies) | .version = $VERSION' > dist/package.json
+
+      - run: cat package.json | jq --arg VERSION "${TAG#v}" 'del(.devDependencies) | .version = $VERSION' > dist/package.json
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+
       - run: rm dist/*.test.*
 
       - run: npm publish --provenance --access public dist/


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated release workflow to ensure the version in published packages no longer includes a leading "v" from the release tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->